### PR TITLE
Fix backups by pruning old branches

### DIFF
--- a/update_repos
+++ b/update_repos
@@ -22,7 +22,7 @@ GITHUB_API_HOST = 'https://api.github.com'
 GIT_CLONE_CMD = 'git clone %s %s %s'
 GIT_CLONE_API_URL = 'https://%s@github.com/%s'
 GIT_SHA_CMD = 'git rev-parse --short %s'
-GIT_FETCH_CMD = 'git fetch'
+GIT_FETCH_CMD = 'git fetch --prune'
 GIT_CHECK_REMOTE_CMD = 'git ls-remote'
 
 USER_DETAILS_PATH = '/users/%s'

--- a/update_repos
+++ b/update_repos
@@ -22,7 +22,7 @@ GITHUB_API_HOST = 'https://api.github.com'
 GIT_CLONE_CMD = 'git clone %s %s %s'
 GIT_CLONE_API_URL = 'https://%s@github.com/%s'
 GIT_SHA_CMD = 'git rev-parse --short %s'
-GIT_FETCH_CMD = 'git fetch --prune --tags'
+GIT_FETCH_CMD = 'git fetch --prune --tags --prune-tags'
 GIT_CHECK_REMOTE_CMD = 'git ls-remote'
 
 USER_DETAILS_PATH = '/users/%s'

--- a/update_repos
+++ b/update_repos
@@ -22,7 +22,7 @@ GITHUB_API_HOST = 'https://api.github.com'
 GIT_CLONE_CMD = 'git clone %s %s %s'
 GIT_CLONE_API_URL = 'https://%s@github.com/%s'
 GIT_SHA_CMD = 'git rev-parse --short %s'
-GIT_FETCH_CMD = 'git fetch --prune'
+GIT_FETCH_CMD = 'git fetch --prune --tags'
 GIT_CHECK_REMOTE_CMD = 'git ls-remote'
 
 USER_DETAILS_PATH = '/users/%s'


### PR DESCRIPTION
Prune while fetching

This job has been failing for the last week:

    ----------------------eos-openqa-tests----------------------
    Using /opt/backups/eos-openqa-tests.git
    - master @ 0c013e2 ..Could not execute git fetch
    error: cannot lock ref 'refs/heads/staging': 'refs/heads/staging/T25144-fix-fbe_language_switch-on-ISOs' exists; cannot create 'refs/heads/staging'
    From github.com:endlessm/eos-openqa-tests
     ! [new branch]      staging    -> staging  (unable to update local ref)
    Terminating early

This is because we previously had branches of the form 'staging/*' in this repo, and we now have only a 'staging' branch (or none). Git doesn't support both at once, but nothing pruned old staging branches.  Prune 'em.

While we're here, back up all tags (not just those that point to commits that are on some branch), and prune them too.

https://phabricator.endlessm.com/T27103