### PR TITLE
Revert "Prune tags as well"

### DIFF
--- a/update_repos
+++ b/update_repos
@@ -22,7 +22,7 @@ GITHUB_API_HOST = 'https://api.github.com'
 GIT_CLONE_CMD = 'git clone %s %s %s'
 GIT_CLONE_API_URL = 'https://%s@github.com/%s'
 GIT_SHA_CMD = 'git rev-parse --short %s'
-GIT_FETCH_CMD = 'git fetch --prune --tags --prune-tags'
+GIT_FETCH_CMD = 'git fetch --prune --tags'
 GIT_CHECK_REMOTE_CMD = 'git ls-remote'
 
 USER_DETAILS_PATH = '/users/%s'


### PR DESCRIPTION
This reverts commit 09aa7c819ac4128619ace3c9142e751c3c5fac98.

Git on the relevant Jenkins job apparently predates 2.17.0 which was released in June 2018.  https://github.com/git/git/blob/master/Documentation/RelNotes/2.17.0.txt#L32-L33

    - master @ 843dcde ..Could not execute git fetch --prune --tags --prune-tags
    error: unknown option `prune-tags'

(It is possible to pass refspecs like "+refs/tags/*:refs/tags/*" to `git fetch`, but not pruning tags seems acceptable.)

https://phabricator.endlessm.com/T27103