### PR TITLE
Revert "Prune while fetching"

### DIFF
--- a/update_repos
+++ b/update_repos
@@ -22,7 +22,7 @@ GITHUB_API_HOST = 'https://api.github.com'
 GIT_CLONE_CMD = 'git clone %s %s %s'
 GIT_CLONE_API_URL = 'https://%s@github.com/%s'
 GIT_SHA_CMD = 'git rev-parse --short %s'
-GIT_FETCH_CMD = 'git fetch --prune --tags'
+GIT_FETCH_CMD = 'git fetch --tags'
 GIT_CHECK_REMOTE_CMD = 'git ls-remote'
 
 USER_DETAILS_PATH = '/users/%s'


### PR DESCRIPTION
This reverts commit 17675937d32c7323be8ac878fbf124f4ed778a1a.  At
https://github.com/endlessm/gh_fetch/pull/3#issuecomment-507526552
@dbnicholson said:

> This defeats the purpose of the backup tool. The backup should keep
> the refs in case the remote has accidentally deleted them. For instance,
> assume that the eos3.4 branch was deleted on the remote. After this
> change, the backup will follow and we'll no longer have any reference to
> the referenced commit.
>
> In 5 years of running this code, this is the 2nd time we've ever run
> into this kind of branch conflict. I don't think we should weaken the
> backup tool to cater to it.

https://phabricator.endlessm.com/T27103